### PR TITLE
AWSデプロイ用にGemfileを編集

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -54,7 +54,7 @@ group :test do
 end
 
 group :production do
-  gem 'pg'
+  gem 'mysql2'
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem


### PR DESCRIPTION
## 概要
HerokuとAWSで設定しているDBが異なったため、AWSに合わせるよう修正（Gemfile）