### PR TITLE
EC2で起きたエラー対応

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -4,7 +4,7 @@ Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
   # Code is not reloaded between requests.
-  config.cache_classes = true
+  config.cache_classes = false
 
   # Eager load code on boot. This eager loads most of Rails and
   # your application in memory, allowing both threaded web servers


### PR DESCRIPTION
## 概要
EC２上で以下のエラー分が発生、その対応を行なった。
```
/home/ec2-user/.rbenv/versions/3.0.0/lib/ruby/gems/3.0.0/gems/spring-4.1.0/lib/spring/application.rb:100:in `block in preload': Spring reloads, and therefore needs the application to have reloading enabled.
Please, set config.cache_classes to false in config/environments/production.rb.
```